### PR TITLE
Add StackApps key option for higher quota

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -32,6 +32,7 @@ image::https://cloud.githubusercontent.com/assets/5674651/25589901/a3124e4a-2eae
   "tags": "tag1;tag2",
   "so": {
     "apiBaseURL": "https://api.stackexchange.com/2.2",
+    "key": "[optional: your StackApps key, for a higher request quota]",
     "dayBack": 1,
     "hourBack": 0,
     "minuteBack": 0
@@ -64,6 +65,7 @@ so.apiBaseURL:: URL of the StackOverflow API.
 so.minuteBack:: number of minutes previous now, use for create the first query.
 so.hourBack:: number of hours previous now, use for create the first query.
 so.dayBack:: number of days previous now, use for create the first query.
+so.key:: an API key from https://stackapps.com/apps/oauth/register/submit to increase your per-day quota from 300 to 10000
 slack.apiBaseUrl:: URL of Slack API.
 slack.token:: Slack token, only for dev purpose. DON'T USE IN PRODUCTION.
 slack.channel:: Name of the channel to publish. (must start with `#`)

--- a/src/bot.js
+++ b/src/bot.js
@@ -6,7 +6,11 @@ const config = require('../config');
 const entities = new Entities();
 
 
-const questionURL = `${config.so.apiBaseURL}/questions?order=desc&sort=activity&tagged=${encodeURIComponent(config.tags)}&site=stackoverflow`;
+let questionURL = `${config.so.apiBaseURL}/questions?order=desc&sort=activity&tagged=${encodeURIComponent(config.tags)}&site=stackoverflow`;
+
+if (config.so.key) {
+  questionURL += `&key=${config.so.key}`;
+}
 
 module.exports = function start() {
   const currentTime = Math.round(Date.now() / 1000);


### PR DESCRIPTION
This PR adds a `so.key` option, so you can make 10000 requests/day instead of 300 requests/day (6 per minute instead of 1 per 15 minutes!)